### PR TITLE
Deprecate Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 [![Unit tests](https://github.com/welfare-state-analytics/riksdagen-corpus/actions/workflows/push.yml/badge.svg)](https://github.com/welfare-state-analytics/riksdagen-corpus/actions/workflows/push.yml)
 [![Validate Parla-Clarin XML](https://github.com/welfare-state-analytics/riksdagen-corpus/actions/workflows/validate.yml/badge.svg)](https://github.com/welfare-state-analytics/riksdagen-corpus/actions/workflows/validate.yml)
 
+# DEPRECIATION NOTICE
+
+The Swedish Parliament Corpus has moved over to the [SWERIK Project](https://github.com/swerik-project/the-swedish-parliament-corpus) github page. v.0.14.0 was the last release under this repository. Please visit the new repo for the most up-to-date releases.
 
 # Swedish parliamentary proceedings --- 1867--today --- v0.14.0
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Unit tests](https://github.com/welfare-state-analytics/riksdagen-corpus/actions/workflows/push.yml/badge.svg)](https://github.com/welfare-state-analytics/riksdagen-corpus/actions/workflows/push.yml)
 [![Validate Parla-Clarin XML](https://github.com/welfare-state-analytics/riksdagen-corpus/actions/workflows/validate.yml/badge.svg)](https://github.com/welfare-state-analytics/riksdagen-corpus/actions/workflows/validate.yml)
 
-# DEPRECIATION NOTICE
+# DEPRECATION NOTICE
 
 The Swedish Parliament Corpus has moved over to the [SWERIK Project](https://github.com/swerik-project/the-swedish-parliament-corpus) github page. v.0.14.0 was the last release under this repository. Please visit the new repo for the most up-to-date releases.
 

--- a/test/chairs.py
+++ b/test/chairs.py
@@ -166,6 +166,7 @@ class Test(unittest.TestCase):
     #  -------------------------------------------
     #
     #  check chair IDs are unique
+    @unittest.skip
     def test_unique_chair_id(self):
         print("Testing: chairs have unique IDs")
         chairs = self.get_chairs()
@@ -175,6 +176,7 @@ class Test(unittest.TestCase):
         self.assertEqual(len(chair_ids), len(set(chair_ids)))
 
     #  check no chairs are numbered higher than the max chair nr for that chamber
+    @unittest.skip
     def test_chair_nrs_in_range(self):
         print("Testing: chairs within max range for chamber")
         chairs = self.get_chairs()
@@ -190,6 +192,7 @@ class Test(unittest.TestCase):
     #  --------------------------------
     #
     #  check chair IDs in chair_mp are the same set as chairs
+    @unittest.skip
     def test_chair_id_sets(self):
         print("Testing: chair ids are the same set in chairs.csv and chair_mp.csv")
         chairs = self.get_chairs()
@@ -201,6 +204,7 @@ class Test(unittest.TestCase):
         self.assertEqual(len(chair_ids_a), len(chair_ids_b))
 
     #  check no chairs from tvåkammartiden are used in enkammartid and vice-versa
+    @unittest.skip
     def test_chair_chambertime_concurrence(self):
         print("Testing: no chairs from tvåkammartiden are used in enkammartid and vice-versa")
         chairs = self.get_chairs()
@@ -233,6 +237,7 @@ class Test(unittest.TestCase):
     #  check that chairs are within acceptable range for a given year
     #      and that every seat within that range is present at least once
     #      in the chair_mp file (whether filled or not)
+    @unittest.skip
     def test_chair_nrs_in_range_for_year(self):
         print("Testing: chairs are within acceptable range for a given year\n     and that every seat within that range is present at least once")
         chairs = self.get_chairs()
@@ -293,7 +298,7 @@ class Test(unittest.TestCase):
     # ---------------------------------------------
     #
     #  check no single person sits in two places at once
-    #@unittest.skip
+    @unittest.skip
     def test_chair_hogs(self):
         print("Testing: no single person sits in two places at once")
         chair_mp = self.get_chair_mp()
@@ -396,7 +401,7 @@ class Test(unittest.TestCase):
         self.assertTrue(no_chair_hogs)
 
     # Check no one is sharing a chare
-    #@unittest.skip
+    @unittest.skip
     def test_knaMP(self):
         print("Testing no one sits on the same chair at the same time")
         config = fetch_config("chairs")
@@ -486,7 +491,7 @@ class Test(unittest.TestCase):
     # ---------------------
     #
     #  test all chairs are filled
-    #@unittest.skip
+    @unittest.skip
     def test_chair_coverage(self):
         print("Test coverage of chair-MP mapping.")
         config = fetch_config("chairs")

--- a/test/chairs.py
+++ b/test/chairs.py
@@ -293,7 +293,7 @@ class Test(unittest.TestCase):
     # ---------------------------------------------
     #
     #  check no single person sits in two places at once
-    @unittest.skip
+    #@unittest.skip
     def test_chair_hogs(self):
         print("Testing: no single person sits in two places at once")
         chair_mp = self.get_chair_mp()
@@ -396,7 +396,7 @@ class Test(unittest.TestCase):
         self.assertTrue(no_chair_hogs)
 
     # Check no one is sharing a chare
-    @unittest.skip
+    #@unittest.skip
     def test_knaMP(self):
         print("Testing no one sits on the same chair at the same time")
         config = fetch_config("chairs")
@@ -486,7 +486,7 @@ class Test(unittest.TestCase):
     # ---------------------
     #
     #  test all chairs are filled
-    @unittest.skip
+    #@unittest.skip
     def test_chair_coverage(self):
         print("Test coverage of chair-MP mapping.")
         config = fetch_config("chairs")

--- a/test/pytestconfig.py
+++ b/test/pytestconfig.py
@@ -9,12 +9,16 @@ Setup:
 
  This is a mini module for repetitive functions related to this strategy for passing params to unittests.
 """
-import json
+import inspect, json, os
 
-
-
+def caller():
+    for frame in inspect.stack()[1:]:
+        if frame.filename[0] != '<':
+            print(os.path.dirname(os.path.relpath(frame.filename)))
+            break
 
 def fetch_config(test):
+    caller()
     try:
         with open("test/_test_config/test.json", 'r') as j:
             d = json.load(j)


### PR DESCRIPTION
- **docs: generate a new accuracy plot**
  

- **docs: update README**
  

- **chore: build module**
  

- **chore: update version plot**
  

- **fix: repl. 'wiki_id' w/ 'swerik_id'**
  

- **fix: repl. wiki_id w/ swerik_id**
  

- **test: split tests into multiple workflows**
  

- **chore: update corpus version**
  

- **chore:update version nr**
  

- **fix: test that takes ages**
  

- **docs: generate a new accuracy plot**
  

- **docs: update README**
  

- **chore: build module**
  

- **add swerik id**
  

- **2024-01-18_reviewing_chairs**
  

- **2024-01-19_reviewing_chairs**
  

- **feat: add unittest based on manually curated data**
  

- **2024-01-22_reviewing_chairs**
  

- **fix: actually run the test**
  

- **fix: renamed pyriksdagen function**
  

- **2022_01_23_1/2_reviewing_chairs**
  

- **2022-01-23_reviewing_chairs_2/2**
  

- **2023_01_24_reviewing_chairs**
  

- **feat: pass args to unittests when running locally**
  

- **fix: handle dates better (sorry for this hot mess)**
  

- **2023-01-25_reviewing_chairs**
  

- **2024-01-26_reviewing_chairs**
  

- **2024_01_29_reviewing_chairs**
  

- **feat: impute MP dates based on riksdagår start-end**
  

- **fix: 1923 did not start in 1905**
  

- **refactor: work with new date handling implementation**
  

- **fix: most recent version line on top of z-index**
  

- **chore: update after new date handling**
  

- **refactor: rewrite pipeline from scratch**
  

- **refactor: use external library for ALTO XML**
  

- **refactor: add XML_NS as a shared variable for the package**
  

- **fix: correct amount of padding when printing XML**
  

- **refactor: rewrite pipeline from scratch**
  

- **fix: digital originals pipeline**
  

- **fix: missing dependency**
  

- **refactor: remove unnecessary code**
  

- **fix: make digital originals first ID unique**
  

- **fix: archive login bug**
  

- **feat: check what protocols exist and run pipeline with the same script**
  

- **fix: remove debugging 'break' statement**
  

- **fix: remove unnecessary imports**
  

- **refactor: split ALTO processing into three functions for generalizability**
  

- **fix: add docstring and wrong var bug**
  

- **feat:pipe local alto files**
  

- **pull from other working branch**
  

- **fix: date inclusivity**
  

- **chore: reformat csv (comma, no extra cols)**
  

- **fix: paragraph ID seed**
  

- **fix: some errors**
  

- **fix: better date handling**
  

- **feat: mapping between swerik_ids and biobook references**
  

- **fix: rm edition statement**
  

- **fix: sort local input filenames**
  

- **fix: remove default version number**
  

- **fix: errors failing the tests**
  

- **fix: errors failing the tests**
  

- **fix: change stupid filename**
  

- **chore: pull from wd**
  

- **docs: describe references_map file**
  

- **reviewing_chairs_2024-02-12**
  

- **reviewing_chairs_2024-02-14**
  

- **reviewing_chairs_2024-02-19**
  

- **feat: post-1994 iorter, and refactor: start rearranging corpus as planned**
  

- **refactor: relocate db unittest data**
  

- **refactor: db test infiles in new location, write local output according to config / pytestconfig**
  

- **chore: query metadata after adding moder orter**
  

- **chore: add readme**
  

- **fix: path stuff**
  

- **reviewing_chairs_2024-02-21**
  

- **fix: sort chair_mp.csv**
  

- **fix: sort chair_mp.csv properly**
  

- **fix: sort chair_mp.csv properly**
  

- **fix: remove duplicates**
  

- **feat: new test**
  

- **feat: get outpath for all test results**
  

- **feat: run empty speeches test on push**
  

- **style: cleaning up formatting**
  

- **fix: filename**
  

- **refactor: input file paths as argparse args**
  

- **docs: generate a new accuracy plot**
  

- **docs: update README**
  

- **chore: build module**
  

- **chore...want to switch branch:**
  

- **feat: add depreciation warning**
  